### PR TITLE
Add unit tests for conditional parsing

### DIFF
--- a/R/org_classify_description_texts.R
+++ b/R/org_classify_description_texts.R
@@ -408,7 +408,7 @@ get_scheduleO <- function(ein) {
       getNodeSet("//FormAndLineReferenceDesc") %>%
       map_chr(xmlValue) 
     
-    out <- glue("From {ref %>% pluck(1)}: {text %>% pluck(1)}")
+    out <- glue("From {ref}: {text}")
 
     # ScheduleO is not present
   } else {

--- a/R/org_classify_description_texts.R
+++ b/R/org_classify_description_texts.R
@@ -328,6 +328,7 @@ get_value_990 <- function(xml_root, type =
     }
     return(ifnotNA(program_desc))
   }
+  
 }
 
 #' Get concrete information from Schedule R

--- a/tests/testthat/test-get-scheduleO.R
+++ b/tests/testthat/test-get-scheduleO.R
@@ -9,11 +9,18 @@ test_that("MoveOn example check", {
   
     })
 
+grepl("http", standardize_url("www.moveon.org"))
 test_that("Check whether the exact document source is provided when inspecting Schedule O", {
     
     # 2019 IRS data 
     data("idx_2019")
     
-    expect_equal(grepl("From FORM", get_scheduleO("061553389")), TRUE)
+    expect_equal(unique(grepl("From FORM", get_scheduleO("061553389"))), TRUE)
 
     })
+
+test_that("Check whether get_scheduleO returns all entries", {
+  
+expect_equal(length(grepl("From FORM", (get_scheduleO("061553389")), TRUE)) >= 2, TRUE)
+  
+  })

--- a/tests/testthat/test-get-value-990.R
+++ b/tests/testthat/test-get-value-990.R
@@ -1,5 +1,6 @@
 library(testthat)
 library(ParseIRS990)
+library(purrr)
 
 context("Standaridze an organization's website address (URL)")
 
@@ -7,4 +8,18 @@ test_that("MoveOn example check", {
   
   expect_equal(grepl("http", standardize_url("www.moveon.org")), TRUE)
   
+})
+
+context("Find values conditional on parsed return types")
+
+test_that("Check whether it's possible to parse both 990 and 990EZ forms", {
+    
+    value_list <- map2(rep(c("200067392", "473779347"), each = 3), rep(c("website", "mission_desc", "program_desc"), times = 2), ~get_value_990(get_990(.x), type = .y))
+
+    # Check whether both document forms are parsed 
+    expect_equal(length(value_list), 6)
+    
+    # Check whether any of the results is null (in these cases, all of the outcomes should be false)
+    expect_equal(sum(map_int(value_list, is.null)), 0)
+
 })

--- a/tests/testthat/test-get-value-990.R
+++ b/tests/testthat/test-get-value-990.R
@@ -1,6 +1,5 @@
 library(testthat)
 library(ParseIRS990)
-library(purrr)
 
 context("Standaridze an organization's website address (URL)")
 
@@ -8,18 +7,4 @@ test_that("MoveOn example check", {
   
   expect_equal(grepl("http", standardize_url("www.moveon.org")), TRUE)
   
-})
-
-context("Find values conditional on parsed return types")
-
-test_that("Check whether it's possible to parse both 990 and 990EZ forms", {
-    
-    value_list <- map2(rep(c("200067392", "473779347"), each = 3), rep(c("website", "mission_desc", "program_desc"), times = 2), ~get_value_990(get_990(.x), type = .y))
-
-    # Check whether both document forms are parsed 
-    expect_equal(length(value_list), 6)
-    
-    # Check whether any of the results is null (in these cases, all of the outcomes should be false)
-    expect_equal(sum(map_int(value_list, is.null)), 0)
-
 })


### PR DESCRIPTION
@milandv It seems that you've already changed the `get_value_990()` function. What I did here is merely adding unit tests that check whether the new function works well with the cases of 990 and 990EZ forms (I used the EINs provided by you for each type). The function passed the test. If the current change is enough to do the job you intended, merge this branch otherwise let me know what I should improve further.  